### PR TITLE
Add LangChain deep agent example and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
 # Deep-Agent
+
+This repository hosts examples that explore deep agent patterns using LangChain
+and LangGraph. The highlighted example demonstrates how a primary
+`AgentExecutor` can delegate work to specialized sub-agents implemented as
+LangGraph workflows.
+
+## Getting started
+
+1. Install dependencies and configure an OpenAI compatible API key as described
+   in the [Deep Agent Example Guide](docs/deep_agent_example.md#prerequisites).
+2. Review the annotated script at
+   [`examples/deep_agent/main.py`](examples/deep_agent/main.py) to understand how
+   language models, tools, and graphs are orchestrated.
+3. Run the example with:
+
+   ```bash
+   python examples/deep_agent/main.py
+   ```
+
+   The script prints the coordinator's response after delegating to research and
+   writing sub-agents.
+
+## Learn more
+
+- The [Deep Agent Example Guide](docs/deep_agent_example.md) explains the code
+  structure and shows how to extend the system with additional sub-agents.
+- The LangChain deep agents overview and blog post provide conceptual context:
+  - https://docs.langchain.com/labs/deep-agents/overview
+  - https://blog.langchain.com/deep-agents/

--- a/docs/deep_agent_example.md
+++ b/docs/deep_agent_example.md
@@ -1,0 +1,76 @@
+# Deep Agent Example Guide
+
+This guide explains how to run the example located at
+`examples/deep_agent/main.py` and customize it to explore LangChain deep agents
+powered by LangGraph.
+
+## Prerequisites
+
+1. **Python environment** – Python 3.9 or newer is recommended.
+2. **Dependencies** – Install the required packages:
+
+   ```bash
+   pip install langchain langchain-openai langgraph
+   ```
+
+3. **API keys** – Export an OpenAI compatible API key so the example can invoke
+   the chat model used by the agents:
+
+   ```bash
+   export OPENAI_API_KEY="sk-your-key"
+   ```
+
+   You can substitute the model provider by editing
+   [`initialize_llm`](../examples/deep_agent/main.py#L27) to use a different
+   LangChain chat model wrapper.
+
+## How the example works
+
+The script is divided into sectioned helpers that map directly to the structure
+of the code:
+
+- **Model setup** – [`initialize_llm`](../examples/deep_agent/main.py#L27) and
+  [`initialize_tools`](../examples/deep_agent/main.py#L44) configure the shared
+  chat model and utility tools that every agent can access.
+- **Graph definition** – [`build_sub_agent_graph`](../examples/deep_agent/main.py#L81)
+  uses LangGraph to define reusable sub-agents with plan/act/report nodes.
+- **Agent registration** – [`build_primary_agent`](../examples/deep_agent/main.py#L136)
+  and [`create_sub_agent_tool`](../examples/deep_agent/main.py#L155) register the
+  LangGraph workflows as tools that the primary `AgentExecutor` can call.
+- **Execution flow** – [`run_example`](../examples/deep_agent/main.py#L172)
+  shows how the coordinator agent assembles the system and invokes a task.
+
+Each of these helpers is documented inline in the script so you can match the
+narrative in this guide with the implementation details.
+
+## Running the script
+
+1. Ensure the prerequisites above are satisfied.
+2. From the repository root, execute:
+
+   ```bash
+   python examples/deep_agent/main.py
+   ```
+
+3. The script prints the final response from the primary agent after delegating
+   work to the research and writing sub-agents.
+
+If you run into authentication errors, double-check that your `OPENAI_API_KEY`
+environment variable is exported in the shell that launches the script.
+
+## Extending the example
+
+To add additional sub-agents:
+
+1. Create a new `SubAgentConfig` with the desired name, tools, and model
+   configuration.
+2. Call [`build_sub_agent_graph`](../examples/deep_agent/main.py#L81) to compile
+   a new LangGraph workflow.
+3. Wrap the compiled graph with [`create_sub_agent_tool`](../examples/deep_agent/main.py#L155)
+   and append the resulting tool to the list passed into
+   [`build_primary_agent`](../examples/deep_agent/main.py#L136).
+4. Update [`run_example`](../examples/deep_agent/main.py#L172) to include the new
+   tool in `delegation_tools`.
+
+Following this pattern keeps the control flow explicit and makes it easy to
+iterate on increasingly capable deep agent systems.

--- a/examples/deep_agent/main.py
+++ b/examples/deep_agent/main.py
@@ -1,0 +1,244 @@
+"""Deep Agent Example.
+
+This module demonstrates how to orchestrate a LangChain AgentExecutor as the
+primary coordinator while delegating specific tasks to LangGraph-powered
+sub-agents. The sections below mirror the accompanying documentation so that
+readers can match conceptual descriptions with the relevant code.
+"""
+
+# --- Model Setup -----------------------------------------------------------
+"""Utilities for configuring language models and tools used by the agents."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, TypedDict
+
+from langchain.agents import AgentExecutor, create_structured_chat_agent
+from langchain.agents.output_parsers import JSONAgentOutputParser
+from langchain.prompts import ChatPromptTemplate, MessagesPlaceholder
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import HumanMessage
+from langchain_core.tools import BaseTool, Tool
+from langchain_openai import ChatOpenAI
+from langgraph.graph import END, StateGraph
+
+
+def initialize_llm(
+    *,
+    model_name: str = "gpt-4o-mini",
+    temperature: float = 0.0,
+    api_key: Optional[str] = None,
+) -> BaseChatModel:
+    """Create a chat model that will power both the primary agent and sub-agents.
+
+    Parameters
+    ----------
+    model_name:
+        The name of the OpenAI compatible model to use.
+    temperature:
+        Sampling temperature controlling creativity of responses.
+    api_key:
+        Optional override for the OpenAI API key. If omitted the environment
+        variable ``OPENAI_API_KEY`` will be used by the LangChain integration.
+    """
+
+    return ChatOpenAI(model=model_name, temperature=temperature, api_key=api_key)
+
+
+def initialize_tools() -> List[BaseTool]:
+    """Define the shared tool set exposed to the agent ecosystem.
+
+    The tools are intentionally simple so the example runs without external
+    services. They still illustrate how to register custom capabilities that can
+    be invoked from both the primary agent and LangGraph sub-agents.
+    """
+
+    def summarize(text: str) -> str:
+        return f"Summary: {text[:200]}..." if len(text) > 200 else f"Summary: {text}"
+
+    def retrieve(keyword: str) -> str:
+        return (
+            "Retrieved knowledge about {keyword}. "
+            "Replace this with a vector store or API call in production"
+        ).format(keyword=keyword)
+
+    return [
+        Tool(
+            name="summarizer",
+            description="Summarize short passages or agent outputs.",
+            func=summarize,
+        ),
+        Tool(
+            name="retriever",
+            description="Retrieve lightweight context for a given keyword.",
+            func=retrieve,
+        ),
+    ]
+
+
+# --- Graph Definition ------------------------------------------------------
+"""LangGraph workflow for reusable sub-agents."""
+
+
+class SubAgentState(TypedDict):
+    """LangGraph state shared across sub-agent nodes."""
+
+    task: str
+    context: List[str]
+    result: Optional[str]
+
+
+@dataclass
+class SubAgentConfig:
+    """Configuration object bundling model, tools, and metadata."""
+
+    name: str
+    llm: BaseChatModel
+    tools: List[BaseTool]
+
+
+def build_sub_agent_graph(config: SubAgentConfig):
+    """Construct a LangGraph workflow representing a single sub-agent.
+
+    The graph contains three conceptual steps: planning, acting, and reporting.
+    Each step is implemented as a node that reads and updates the shared state.
+    """
+
+    workflow = StateGraph(SubAgentState)
+
+    def plan(state: SubAgentState) -> SubAgentState:
+        prompt = ChatPromptTemplate.from_messages(
+            [
+                (
+                    "system",
+                    (
+                        "You are the {name} sub-agent. Plan how you will approach "
+                        "the task using the available tools: {tool_names}."
+                    ),
+                ),
+                ("human", "Task: {task}"),
+            ]
+        ).format_messages(
+            name=config.name, task=state["task"], tool_names=", ".join(t.name for t in config.tools)
+        )
+        message = config.llm.invoke(prompt)
+        state.setdefault("context", []).append(message.content)
+        return state
+
+    def act(state: SubAgentState) -> SubAgentState:
+        # For brevity the action chooses the first tool. Replace with reasoning
+        # loops for richer examples.
+        tool = config.tools[0]
+        state["result"] = tool.invoke(state["task"])
+        state.setdefault("context", []).append(state["result"])
+        return state
+
+    def report(state: SubAgentState) -> SubAgentState:
+        response = config.llm.invoke(
+            [
+                ("system", f"Summarize the {config.name} sub-agent outcome."),
+                ("human", "\n".join(state.get("context", []))),
+            ]
+        )
+        state["result"] = response.content
+        state.setdefault("context", []).append(response.content)
+        return state
+
+    workflow.add_node("plan", plan)
+    workflow.add_node("act", act)
+    workflow.add_node("report", report)
+
+    workflow.set_entry_point("plan")
+    workflow.add_edge("plan", "act")
+    workflow.add_edge("act", "report")
+    workflow.add_edge("report", END)
+
+    return workflow.compile()
+
+
+# --- Agent Registration ----------------------------------------------------
+"""Primary agent definition and utilities for invoking sub-agents."""
+
+
+def build_primary_agent(llm: BaseChatModel, tools: Iterable[BaseTool]) -> AgentExecutor:
+    """Create an AgentExecutor that delegates structured tasks to sub-agents."""
+
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            (
+                "system",
+                "You are the coordinator. When appropriate, call the provided tools \"
+                "delegate_to_<name>\" to request help from specialized sub-agents."
+            ),
+            MessagesPlaceholder(variable_name="chat_history"),
+            ("human", "{input}"),
+            (
+                "assistant",
+                "{agent_scratchpad}",
+            ),
+        ]
+    )
+
+    agent = create_structured_chat_agent(
+        llm=llm,
+        tools=list(tools),
+        prompt=prompt,
+        output_parser=JSONAgentOutputParser(),
+    )
+    return AgentExecutor(agent=agent, tools=list(tools), verbose=True)
+
+
+def create_sub_agent_tool(name: str, graph) -> BaseTool:
+    """Wrap a compiled LangGraph workflow as a LangChain Tool."""
+
+    def run(task: str) -> str:
+        result = graph.invoke({"task": task, "context": []})
+        return result.get("result", "No result")
+
+    return Tool(
+        name=f"delegate_to_{name}",
+        description=f"Delegate the task to the {name} sub-agent.",
+        func=run,
+    )
+
+
+# --- Execution -------------------------------------------------------------
+"""Entrypoint showcasing how the primary agent delegates to sub-agents."""
+
+
+def run_example(query: str) -> Dict[str, Any]:
+    """Execute the deep agent example and return the full agent response."""
+
+    base_llm = initialize_llm()
+    shared_tools = initialize_tools()
+
+    research_config = SubAgentConfig(name="research", llm=base_llm, tools=shared_tools)
+    writing_config = SubAgentConfig(name="writing", llm=base_llm, tools=shared_tools)
+
+    research_graph = build_sub_agent_graph(research_config)
+    writing_graph = build_sub_agent_graph(writing_config)
+
+    delegation_tools = list(shared_tools) + [
+        create_sub_agent_tool("research", research_graph),
+        create_sub_agent_tool("writing", writing_graph),
+    ]
+
+    primary_agent = build_primary_agent(base_llm, delegation_tools)
+
+    response = primary_agent.invoke(
+        {"input": query, "chat_history": [HumanMessage(content=query)]}
+    )
+    return response
+
+
+def main() -> None:
+    """Run the example when executed as a script."""
+
+    query = "Draft a short blog outline about LangGraph-based deep agents."
+    result = run_example(query)
+    print("\nPrimary agent response:\n", result["output"])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a deep agent example script that combines a LangChain AgentExecutor with LangGraph-based sub-agents
- provide documentation that explains prerequisites, execution, and extension steps
- update the README to point to the example and supporting guide

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d95bf3e084833184d70ffd216efa5c