### PR TITLE
Add basic LangGraph example with inline tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,15 @@ and LangGraph. The highlighted example demonstrates how a primary
 `AgentExecutor` can delegate work to specialized sub-agents implemented as
 LangGraph workflows.
 
+## Examples
+
+- [`examples/langgraph_basic/main.py`](examples/langgraph_basic/main.py) shows a
+  minimal LangGraph workflow that relies on inline tools and a single agent
+  node—no `AgentExecutor` required.
+- [`examples/deep_agent/main.py`](examples/deep_agent/main.py) expands on that
+  foundation by introducing a coordinating `AgentExecutor` that can dispatch to
+  multiple LangGraph sub-agents.
+
 ## Getting started
 
 1. Install dependencies and configure an OpenAI compatible API key as described

--- a/docs/langgraph_basic_example.md
+++ b/docs/langgraph_basic_example.md
@@ -1,0 +1,25 @@
+# LangGraph Basic Example
+
+The script at [`examples/langgraph_basic/main.py`](../examples/langgraph_basic/main.py)
+illustrates the smallest useful LangGraph workflow:
+
+1. A typed state dictionary keeps track of the incoming query, scratchpad
+   updates, and final result so each node shares a predictable structure.
+2. Inline Python callables are registered as tools. They do not require network
+   access and highlight how pure functions can be wrapped with lightweight
+   metadata.
+3. A single agent node decides which tool to use, invokes it, and appends
+   human-readable traces to the scratchpad.
+4. The workflow is wired together with `StateGraph`, compiled, and executed via
+   a simple CLI helper.
+
+Run the example to observe the trace:
+
+```bash
+python examples/langgraph_basic/main.py
+```
+
+Compared with the [Deep Agent example](deep_agent_example.md), this workflow
+remains entirely within LangGraph—no `AgentExecutor` orchestrator. The deeper
+example layers an `AgentExecutor` on top so a coordinator LLM can delegate work
+across multiple LangGraph sub-agents.

--- a/examples/langgraph_basic/main.py
+++ b/examples/langgraph_basic/main.py
@@ -1,0 +1,133 @@
+"""Minimal LangGraph workflow with inline tools.
+
+This script accompanies the documentation that contrasts a lightweight
+LangGraph-only workflow with the deeper AgentExecutor-driven orchestration in
+``examples/deep_agent``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, List, TypedDict
+
+from langgraph.graph import END, StateGraph
+
+
+# --- State definition -------------------------------------------------------
+class BasicState(TypedDict, total=False):
+    """Structure of the state object flowing through the LangGraph."""
+
+    query: str
+    scratchpad: List[str]
+    result: str
+
+
+# --- Tool registration ------------------------------------------------------
+@dataclass(frozen=True)
+class InlineTool:
+    """Simple callable wrapper with metadata for instructional purposes."""
+
+    name: str
+    description: str
+    func: Callable[[str], str]
+
+    def __call__(self, text: str) -> str:
+        return self.func(text)
+
+
+def build_toolkit() -> Dict[str, InlineTool]:
+    """Create the inline tools used by the agent node."""
+
+    def to_upper(text: str) -> str:
+        return text.upper()
+
+    def word_count(text: str) -> str:
+        count = len(text.split())
+        return f"The prompt contains {count} words."
+
+    def reverse(text: str) -> str:
+        return text[::-1]
+
+    tools = [
+        InlineTool(
+            name="uppercase",
+            description="Convert the entire string to uppercase characters.",
+            func=to_upper,
+        ),
+        InlineTool(
+            name="word_count",
+            description="Count how many words are present in the string.",
+            func=word_count,
+        ),
+        InlineTool(
+            name="reverse",
+            description="Reverse the characters in the supplied string.",
+            func=reverse,
+        ),
+    ]
+    return {tool.name: tool for tool in tools}
+
+
+# --- Node implementations ---------------------------------------------------
+def choose_tool(query: str, tools: Dict[str, InlineTool]) -> InlineTool:
+    """Naively select an inline tool based on keyword heuristics."""
+
+    lowered = query.lower()
+    if "upper" in lowered or "shout" in lowered:
+        return tools["uppercase"]
+    if "count" in lowered:
+        return tools["word_count"]
+    return tools["reverse"]
+
+
+def build_agent_node(tools: Dict[str, InlineTool]):
+    """Create the lone agent node responsible for dispatching to tools."""
+
+    def agent(state: BasicState) -> BasicState:
+        scratchpad = list(state.get("scratchpad", []))
+        scratchpad.append(f"Received query: {state['query']}")
+
+        tool = choose_tool(state["query"], tools)
+        scratchpad.append(f"Selected tool: {tool.name}")
+        scratchpad.append(f"Tool description: {tool.description}")
+
+        result = tool(state["query"])
+        scratchpad.append(f"Tool output: {result}")
+
+        return {
+            "query": state["query"],
+            "scratchpad": scratchpad,
+            "result": result,
+        }
+
+    return agent
+
+
+# --- Graph construction -----------------------------------------------------
+def build_basic_graph() -> StateGraph[BasicState]:
+    """Assemble the minimal graph with a single agent node."""
+
+    tools = build_toolkit()
+    workflow: StateGraph[BasicState] = StateGraph(BasicState)
+    workflow.add_node("agent", build_agent_node(tools))
+    workflow.set_entry_point("agent")
+    workflow.add_edge("agent", END)
+    return workflow
+
+
+# --- CLI helper -------------------------------------------------------------
+def main() -> None:
+    """Run the basic LangGraph workflow for a sample query."""
+
+    graph = build_basic_graph().compile()
+    query = "Please count the words in LangGraph makes agents modular"
+    final_state = graph.invoke({"query": query, "scratchpad": []})
+    print("Query:", query)
+    print("Result:", final_state.get("result"))
+    print("Scratchpad:")
+    for line in final_state.get("scratchpad", []):
+        print("  -", line)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a minimal LangGraph example that demonstrates a typed state graph, inline tools, and a single agent node
- document the new example in the docs and link to it from the README to contrast it with the deep agent workflow

## Testing
- `python examples/langgraph_basic/main.py` *(fails: ModuleNotFoundError: No module named 'langgraph'; dependency not installed in container)*

------
https://chatgpt.com/codex/tasks/task_b_68da012bf6a48331a6e454828767c1b0