### PR TITLE
Add Outlook Graph action helpers and coordinator safeguards

### DIFF
--- a/integrations/outlook.py
+++ b/integrations/outlook.py
@@ -9,16 +9,21 @@ that they can be consumed by agents in the repository's examples.
 from __future__ import annotations
 
 import os
+import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime, time, timedelta
-from typing import Dict, Iterable, List, Optional
+from typing import Dict, Iterable, List, Optional, Sequence
 
 import msal
 import requests
-from langchain_core.tools import Tool
+from langchain_core.tools import StructuredTool, Tool
+from pydantic import BaseModel, Field, validator
 
 GRAPH_SCOPE = ["https://graph.microsoft.com/.default"]
 GRAPH_BASE_URL = "https://graph.microsoft.com/v1.0"
+
+
+logger = logging.getLogger(__name__)
 
 
 class OutlookIntegrationError(RuntimeError):
@@ -93,6 +98,42 @@ class OutlookClient:
                 f"Graph API request failed ({response.status_code}): {response.text}"
             )
         return response.json()
+
+    def _authorized_post(self, url: str, payload: Optional[Dict] = None) -> Dict:
+        token = self._get_access_token()
+        response = self._session.post(
+            url,
+            json=payload or {},
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+            },
+            timeout=30,
+        )
+        if response.status_code not in {200, 201, 202, 204}:
+            raise OutlookIntegrationError(
+                f"Graph API POST failed ({response.status_code}): {response.text}"
+            )
+        if not response.content:
+            return {}
+        try:
+            return response.json()
+        except ValueError:
+            return {}
+
+    @staticmethod
+    def _format_recipients(addresses: Sequence[str]) -> List[Dict[str, Dict[str, str]]]:
+        recipients: List[Dict[str, Dict[str, str]]] = []
+        for address in addresses:
+            if not address:
+                continue
+            trimmed = address.strip()
+            if not trimmed:
+                continue
+            recipients.append({"emailAddress": {"address": trimmed}})
+        if not recipients:
+            raise OutlookIntegrationError("At least one recipient email address is required.")
+        return recipients
 
     @staticmethod
     def _previous_workday_range(now: Optional[datetime] = None) -> Dict[str, datetime]:
@@ -210,6 +251,129 @@ class OutlookClient:
     def previous_day_calendar_summary(self) -> str:
         return self.summarize_events(self.fetch_previous_day_events())
 
+    def send_mail(
+        self,
+        *,
+        subject: str,
+        body: str,
+        to_recipients: Sequence[str],
+        cc_recipients: Optional[Sequence[str]] = None,
+        bcc_recipients: Optional[Sequence[str]] = None,
+        save_to_sent_items: bool = True,
+    ) -> str:
+        payload = {
+            "message": {
+                "subject": subject,
+                "body": {"contentType": "Text", "content": body},
+                "toRecipients": self._format_recipients(to_recipients),
+            },
+            "saveToSentItems": save_to_sent_items,
+        }
+        if cc_recipients:
+            payload["message"]["ccRecipients"] = self._format_recipients(cc_recipients)
+        if bcc_recipients:
+            payload["message"]["bccRecipients"] = self._format_recipients(bcc_recipients)
+
+        logger.info("Sending Outlook email with subject '%s' to %s", subject, to_recipients)
+        self._authorized_post(f"{GRAPH_BASE_URL}/me/sendMail", payload)
+        return "Email sent successfully."
+
+    def reply_to_message(
+        self,
+        *,
+        message_id: str,
+        comment: str,
+        reply_all: bool = False,
+    ) -> str:
+        endpoint = "replyAll" if reply_all else "reply"
+        payload = {"comment": comment}
+        logger.info("Replying to Outlook message %s (reply_all=%s)", message_id, reply_all)
+        self._authorized_post(f"{GRAPH_BASE_URL}/me/messages/{message_id}/{endpoint}", payload)
+        return "Reply sent successfully."
+
+    def forward_message(
+        self,
+        *,
+        message_id: str,
+        comment: str,
+        to_recipients: Sequence[str],
+    ) -> str:
+        payload = {
+            "comment": comment,
+            "toRecipients": self._format_recipients(to_recipients),
+        }
+        logger.info("Forwarding Outlook message %s to %s", message_id, to_recipients)
+        self._authorized_post(f"{GRAPH_BASE_URL}/me/messages/{message_id}/forward", payload)
+        return "Forward sent successfully."
+
+    def create_meeting(
+        self,
+        *,
+        subject: str,
+        start: str,
+        end: str,
+        attendees: Sequence[str],
+        body: str = "",
+        location: Optional[str] = None,
+    ) -> str:
+        event_payload = {
+            "subject": subject,
+            "body": {"contentType": "Text", "content": body},
+            "start": {"dateTime": start, "timeZone": "UTC"},
+            "end": {"dateTime": end, "timeZone": "UTC"},
+            "attendees": [
+                {
+                    "emailAddress": {"address": addr.strip()},
+                    "type": "required",
+                }
+                for addr in attendees
+                if addr.strip()
+            ],
+        }
+        if not event_payload["attendees"]:
+            raise OutlookIntegrationError("At least one attendee is required to create a meeting.")
+        if location:
+            event_payload["location"] = {"displayName": location}
+
+        logger.info(
+            "Creating Outlook meeting '%s' from %s to %s for attendees %s",
+            subject,
+            start,
+            end,
+            attendees,
+        )
+        self._authorized_post(f"{GRAPH_BASE_URL}/me/events", event_payload)
+        return "Meeting created successfully."
+
+    def respond_to_invite(
+        self,
+        *,
+        event_id: str,
+        response: str,
+        comment: str = "",
+        send_response: bool = True,
+    ) -> str:
+        normalized = response.lower()
+        endpoint_map = {
+            "accept": "accept",
+            "decline": "decline",
+            "tentative": "tentativelyAccept",
+        }
+        if normalized not in endpoint_map:
+            raise OutlookIntegrationError(
+                "Response must be one of 'accept', 'decline', or 'tentative'."
+            )
+        payload = {"comment": comment, "sendResponse": send_response}
+        endpoint = endpoint_map[normalized]
+        logger.info(
+            "Responding to Outlook invite %s with '%s' (send_response=%s)",
+            event_id,
+            normalized,
+            send_response,
+        )
+        self._authorized_post(f"{GRAPH_BASE_URL}/me/events/{event_id}/{endpoint}", payload)
+        return f"Invite response '{normalized}' sent successfully."
+
 
 def create_outlook_tools(client: Optional[OutlookClient] = None) -> List[Tool]:
     """Create LangChain tools that expose Outlook email and calendar summaries."""
@@ -222,7 +386,111 @@ def create_outlook_tools(client: Optional[OutlookClient] = None) -> List[Tool]:
     def calendar_summary_tool(_: str = "") -> str:
         return client.previous_day_calendar_summary()
 
-    return [
+    class SendMailInput(BaseModel):
+        """Schema for composing and sending a new Outlook email."""
+
+        subject: str = Field(..., description="Email subject line.")
+        body: str = Field(..., description="Plain text body of the email message.")
+        to_recipients: List[str] = Field(
+            ..., description="List of primary recipient email addresses."
+        )
+        cc_recipients: List[str] = Field(
+            default_factory=list,
+            description="Optional list of CC recipient email addresses.",
+        )
+        bcc_recipients: List[str] = Field(
+            default_factory=list,
+            description="Optional list of BCC recipient email addresses.",
+        )
+        save_to_sent_items: bool = Field(
+            default=True,
+            description="Whether to save the message to the Sent Items folder.",
+        )
+
+        @validator("to_recipients", "cc_recipients", "bcc_recipients", pre=True)
+        def _ensure_list(cls, value):  # type: ignore[override]
+            if value is None:
+                return []
+            if isinstance(value, str):
+                return [value]
+            return list(value)
+
+    class ReplyToMessageInput(BaseModel):
+        """Schema for replying to an existing Outlook email."""
+
+        message_id: str = Field(..., description="Graph message ID to reply to.")
+        comment: str = Field(
+            default="",
+            description="Optional note included in the reply body.",
+        )
+        reply_all: bool = Field(
+            default=False,
+            description="Whether to send the reply to all original recipients.",
+        )
+
+    class ForwardMessageInput(BaseModel):
+        """Schema for forwarding an Outlook email."""
+
+        message_id: str = Field(..., description="Graph message ID to forward.")
+        comment: str = Field(
+            default="",
+            description="Optional text added to the forwarded message.",
+        )
+        to_recipients: List[str] = Field(
+            ..., description="Email addresses that should receive the forward."
+        )
+
+        @validator("to_recipients", pre=True)
+        def _ensure_forward_list(cls, value):  # type: ignore[override]
+            if isinstance(value, str):
+                return [value]
+            return list(value)
+
+    class CreateMeetingInput(BaseModel):
+        """Schema for creating a new Outlook meeting."""
+
+        subject: str = Field(..., description="Meeting subject line.")
+        start: str = Field(
+            ..., description="Meeting start timestamp in ISO 8601 format (UTC)."
+        )
+        end: str = Field(
+            ..., description="Meeting end timestamp in ISO 8601 format (UTC)."
+        )
+        attendees: List[str] = Field(
+            ..., description="Email addresses of required attendees."
+        )
+        body: str = Field(
+            default="",
+            description="Optional agenda or notes included in the invite.",
+        )
+        location: Optional[str] = Field(
+            default=None,
+            description="Optional display name for the meeting location.",
+        )
+
+        @validator("attendees", pre=True)
+        def _ensure_attendees(cls, value):  # type: ignore[override]
+            if isinstance(value, str):
+                return [value]
+            return list(value)
+
+    class RespondToInviteInput(BaseModel):
+        """Schema for responding to an Outlook meeting invitation."""
+
+        event_id: str = Field(..., description="Graph event ID for the invitation.")
+        response: str = Field(
+            ..., description="Response type: accept, decline, or tentative."
+        )
+        comment: str = Field(
+            default="",
+            description="Optional note sent with the response.",
+        )
+        send_response: bool = Field(
+            default=True,
+            description="Whether Outlook should send a response email.",
+        )
+
+    tools: List[Tool] = [
         Tool(
             name="outlook_email_summary",
             description=(
@@ -239,7 +507,54 @@ def create_outlook_tools(client: Optional[OutlookClient] = None) -> List[Tool]:
             ),
             func=calendar_summary_tool,
         ),
+        StructuredTool.from_function(
+            name="outlook_send_mail",
+            description=(
+                "Send a new Outlook email. Use only after the user confirms the "
+                "recipients, subject, and body are correct."
+            ),
+            func=lambda **kwargs: client.send_mail(**kwargs),
+            args_schema=SendMailInput,
+        ),
+        StructuredTool.from_function(
+            name="outlook_reply_to_message",
+            description=(
+                "Reply to an existing Outlook message by ID. Confirm the user wants "
+                "to reply and whether to include all recipients before calling."
+            ),
+            func=lambda **kwargs: client.reply_to_message(**kwargs),
+            args_schema=ReplyToMessageInput,
+        ),
+        StructuredTool.from_function(
+            name="outlook_forward_message",
+            description=(
+                "Forward an Outlook message to new recipients. Ensure forwarding is "
+                "explicitly requested and the destination addresses are confirmed."
+            ),
+            func=lambda **kwargs: client.forward_message(**kwargs),
+            args_schema=ForwardMessageInput,
+        ),
+        StructuredTool.from_function(
+            name="outlook_create_meeting",
+            description=(
+                "Schedule a new Outlook meeting. Require user confirmation of "
+                "timing, attendees, and agenda before executing."
+            ),
+            func=lambda **kwargs: client.create_meeting(**kwargs),
+            args_schema=CreateMeetingInput,
+        ),
+        StructuredTool.from_function(
+            name="outlook_respond_to_invite",
+            description=(
+                "Respond to an Outlook meeting invitation. Only call after the user "
+                "specifies the desired response."
+            ),
+            func=lambda **kwargs: client.respond_to_invite(**kwargs),
+            args_schema=RespondToInviteInput,
+        ),
     ]
+
+    return tools
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- extend the Outlook client with Microsoft Graph helpers for sending, replying, forwarding, scheduling, and responding to invites, including structured LangChain tools
- add JSON-validated schemas and logging to the new mutation helpers for safer execution
- update the coordinator prompt and initialization logic to explain Outlook action usage and log loaded tools

## Testing
- python -m compileall integrations/outlook.py examples/deep_agent/main.py

------
https://chatgpt.com/codex/tasks/task_b_68db1f9a9a388331ac507ae5491c9010