### PR TITLE
Add Outlook email prioritization tooling

### DIFF
--- a/docs/deep_agent_example.md
+++ b/docs/deep_agent_example.md
@@ -42,9 +42,11 @@ powered by LangGraph.
    ```
 
    These values are consumed by
-   [`create_outlook_tools`](../integrations/outlook.py#L214), which builds the
+   [`create_outlook_tools`](../integrations/outlook.py), which builds the
    LangChain tools that summarize the previous workday's email and calendar
-   activity.
+   activity. The Outlook integration also exposes a
+   `outlook_top_priority_emails` tool that scores messages using importance
+   flags, sender rules, and due dates so the agent can spotlight urgent emails.
 
 ## How the example works
 
@@ -77,7 +79,9 @@ narrative in this guide with the implementation details.
 3. The script prints the final response from the primary agent after delegating
    work to the research and writing sub-agents. When the Outlook integration is
    configured, the agent can call tools that summarize the previous workday's
-   emails and calendar events.
+   emails and calendar events. The final response now includes a **Top priorities**
+   section populated from the prioritization tool so you can immediately review
+   urgent messages.
 
 If you run into authentication errors, double-check that the `OPENAI_API_KEY`,
 `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_CLIENT_SECRET` environment

--- a/examples/deep_agent/main.py
+++ b/examples/deep_agent/main.py
@@ -163,7 +163,16 @@ def build_primary_agent(llm: BaseChatModel, tools: Iterable[BaseTool]) -> AgentE
                     "Use Outlook action tools (send, reply, forward, schedule meetings, "
                     "respond to invites) only after the user has explicitly confirmed "
                     "the intent, recipients, timing, and message contents. Always note "
-                    "that confirmation in your scratchpad before acting."
+                    "that confirmation in your scratchpad before acting. "
+                    "Before you give a final answer, call the tool \"outlook_top_priority_emails\" "
+                    "when Outlook data is relevant so you can surface urgent items. "
+                    "Format your final response as Markdown with the sections:\n"
+                    "Top priorities:\n"
+                    "- Use the tool output to list the highest scoring emails, or say 'None'.\n"
+                    "Summary:\n"
+                    "- Outline your reasoning and any progress made.\n"
+                    "Next steps:\n"
+                    "- Provide clear follow-up actions for the user."
                 ),
             ),
             MessagesPlaceholder(variable_name="chat_history"),


### PR DESCRIPTION
## Summary
- add prioritization heuristics, recommendations, and metadata scoring to the Outlook ingestion pipeline
- expose a LangChain tool that returns the top scored emails with supporting context
- update the deep agent prompt and documentation to surface a Top priorities section in final responses

## Testing
- python -m compileall integrations examples docs

------
https://chatgpt.com/codex/tasks/task_b_68db2ec1033c8331b748b0047254125f