### PR TITLE
Add Outlook daily briefing tool to Deep Agent example

### DIFF
--- a/examples/deep_agent/main.py
+++ b/examples/deep_agent/main.py
@@ -180,6 +180,9 @@ def build_primary_agent(llm: BaseChatModel, tools: Iterable[BaseTool]) -> AgentE
                 (
                     "You are the coordinator. When appropriate, call the provided tools "
                     '"delegate_to_<name>" to request help from specialized sub-agents. "'
+                    "Use the Outlook daily briefing tool when the user asks for a "
+                    "combined recap of email and calendar activity from the previous "
+                    "workday. "
                     "Use Outlook action tools (send, reply, forward, schedule meetings, "
                     "respond to invites) only after the user has explicitly confirmed "
                     "the intent, recipients, timing, and message contents. Always note "

--- a/integrations/outlook.py
+++ b/integrations/outlook.py
@@ -251,6 +251,21 @@ class OutlookClient:
     def previous_day_calendar_summary(self) -> str:
         return self.summarize_events(self.fetch_previous_day_events())
 
+    def previous_day_briefing(self) -> str:
+        """Combine email and calendar summaries into a single briefing."""
+
+        email_summary = self.previous_day_email_summary()
+        calendar_summary = self.previous_day_calendar_summary()
+        briefing_lines = [
+            "Previous workday briefing:",
+            "Here is a combined snapshot of your inbox activity and meetings.",
+            "",
+            email_summary,
+            "",
+            calendar_summary,
+        ]
+        return "\n".join(briefing_lines)
+
     def send_mail(
         self,
         *,
@@ -386,6 +401,9 @@ def create_outlook_tools(client: Optional[OutlookClient] = None) -> List[Tool]:
     def calendar_summary_tool(_: str = "") -> str:
         return client.previous_day_calendar_summary()
 
+    def daily_briefing_tool(_: str = "") -> str:
+        return client.previous_day_briefing()
+
     class SendMailInput(BaseModel):
         """Schema for composing and sending a new Outlook email."""
 
@@ -506,6 +524,14 @@ def create_outlook_tools(client: Optional[OutlookClient] = None) -> List[Tool]:
                 "and key attendees."
             ),
             func=calendar_summary_tool,
+        ),
+        Tool(
+            name="outlook_daily_briefing",
+            description=(
+                "Provide a combined previous workday briefing that blends email "
+                "highlights with the calendar overview."
+            ),
+            func=daily_briefing_tool,
         ),
         StructuredTool.from_function(
             name="outlook_send_mail",


### PR DESCRIPTION
## Summary
- add an Outlook client helper that combines the previous workday email and calendar summaries into a single narrative briefing
- expose the new helper as the `outlook_daily_briefing` LangChain tool and wire it into the shared tool list
- update the Deep Agent coordinator prompt to mention the briefing tool while ensuring both research and writing sub-agents receive the shared Outlook tools

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68db3017f88c8331910fa3037ddc9261