### PR TITLE
Add Outlook follow-up recommendations tool

### DIFF
--- a/examples/deep_agent/main.py
+++ b/examples/deep_agent/main.py
@@ -183,7 +183,10 @@ def build_primary_agent(llm: BaseChatModel, tools: Iterable[BaseTool]) -> AgentE
                     "Use Outlook action tools (send, reply, forward, schedule meetings, "
                     "respond to invites) only after the user has explicitly confirmed "
                     "the intent, recipients, timing, and message contents. Always note "
-                    "that confirmation in your scratchpad before acting."
+                    "that confirmation in your scratchpad before acting. If the user "
+                    "requests priorities or follow-up recommendations, first call "
+                    "outlook_follow_up_recommendations and then suggest replying or "
+                    "forwarding based on the ranked items."
                 ),
             ),
             MessagesPlaceholder(variable_name="chat_history"),


### PR DESCRIPTION
## Summary
- add Outlook Graph query and ranking utility for unread or flagged follow-up messages
- expose a follow-up recommendation StructuredTool and document how to pair it with reply/forward actions
- guide the coordinator prompt to call the recommendation tool when prioritization help is requested

## Testing
- python -m compileall integrations/outlook.py examples/deep_agent/main.py

------
https://chatgpt.com/codex/tasks/task_b_68db3021757c8331a55319553e28a1b3