### PR TITLE
Add prioritized Outlook email scoring and reporting

### DIFF
--- a/docs/deep_agent_example.md
+++ b/docs/deep_agent_example.md
@@ -43,9 +43,14 @@ powered by LangGraph.
    ```
 
    These values are consumed by
-   [`create_outlook_tools`](../integrations/outlook.py#L214), which builds the
+   [`create_outlook_tools`](../integrations/outlook.py), which builds the
    LangChain tools that summarize the previous workday's email and calendar
-   activity.
+   activity. Optionally, set `OUTLOOK_PRIORITY_SENDERS` to a comma-separated
+   list of prioritized email addresses (or `@domain.com` domain rules). You can
+   assign weights with `address:weight` pairs (for example,
+   `ceo@example.com:5,@executive.example.com:4`). These rules feed the
+   `outlook_top_email_priorities` tool that highlights urgent follow-ups in the
+   agent's final response.
 
 5. **Google Drive access** – Choose one of the following authentication flows
    so the example can call the Drive metadata APIs:

--- a/examples/deep_agent/main.py
+++ b/examples/deep_agent/main.py
@@ -183,7 +183,12 @@ def build_primary_agent(llm: BaseChatModel, tools: Iterable[BaseTool]) -> AgentE
                     "Use Outlook action tools (send, reply, forward, schedule meetings, "
                     "respond to invites) only after the user has explicitly confirmed "
                     "the intent, recipients, timing, and message contents. Always note "
-                    "that confirmation in your scratchpad before acting."
+                    "that confirmation in your scratchpad before acting. Before "
+                    "producing a final answer, consult the `outlook_top_email_priorities` "
+                    "tool when it is available to surface urgent Outlook follow-ups. "
+                    "Your final answer must include a 'Top priorities' section populated "
+                    "with the tool output (or an explicit note if none are returned) "
+                    "before any other closing remarks."
                 ),
             ),
             MessagesPlaceholder(variable_name="chat_history"),


### PR DESCRIPTION
## Summary
- add heuristic scoring for Outlook email ingestion to rank previous workday messages
- expose a top email priorities LangChain tool that returns prioritized metadata
- instruct the deep agent prompt to surface a "Top priorities" section and document sender configuration options

## Testing
- python -m compileall integrations/outlook.py examples/deep_agent/main.py

------
https://chatgpt.com/codex/tasks/task_b_68db3162bc74833180b6af76aa801c27